### PR TITLE
Synchronisation Google Fit depuis l'historique (séances, poids, nutrition)

### DIFF
--- a/src/components/CalorieCounter.jsx
+++ b/src/components/CalorieCounter.jsx
@@ -26,6 +26,14 @@ import {
   getFoodDefaultQuantity,
   formatFoodQuantity
 } from '../data/foodDatabase';
+import GoogleFitSyncButton from './GoogleFitSyncButton';
+import GoogleFitItemButton from './GoogleFitItemButton';
+import {
+  getUnsyncedNutritionDays,
+  syncAllNutritionDays,
+  syncNutritionDayToGoogleFit,
+  isSyncedWithGoogleFit
+} from '../services/GoogleFitSync';
 import './CalorieCounter.css';
 
 const normalizeFoodSearchText = (value) =>
@@ -335,6 +343,25 @@ const CalorieCounter = () => {
             <Settings size={16} /> Ajuster Objectif
           </button>
         </div>
+      </div>
+
+      {/* Synchronisation Google Fit */}
+      <div className="gfit-nutrition-sync" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
+        <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+          <GoogleFitItemButton
+            synced={isSyncedWithGoogleFit('nutrition', selectedDate)}
+            onSync={() => syncNutritionDayToGoogleFit(selectedDate)}
+            allowResync
+            title="Synchroniser cette journée avec Google Fit"
+          />
+          <span style={{ fontSize: '0.8rem', color: '#a1a1aa' }}>Synchroniser ce jour</span>
+        </div>
+        <GoogleFitSyncButton
+          getUnsyncedCount={() => getUnsyncedNutritionDays().length}
+          onSync={syncAllNutritionDays}
+          noun="jour"
+          nounPlural="jours"
+        />
       </div>
 
       {/* Macros Tracker */}

--- a/src/components/GoogleFitItemButton.jsx
+++ b/src/components/GoogleFitItemButton.jsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import googleFitIcon from '../icons/google-fit.svg';
+import './GoogleFitSync.css';
+
+/**
+ * Petit bouton de synchronisation Google Fit pour un élément individuel.
+ * @param {boolean} synced - true si déjà synchronisé (état initial).
+ * @param {() => Promise<void>} onSync - lance la synchro de l'élément.
+ * @param {boolean} allowResync - si true, le bouton reste cliquable après succès
+ *   (utile pour la nutrition d'une journée encore modifiable).
+ */
+const GoogleFitItemButton = ({ synced = false, onSync, allowResync = false, title = 'Synchroniser avec Google Fit' }) => {
+  const [state, setState] = useState(synced ? 'done' : 'idle'); // idle | loading | done | error
+
+  const handleClick = async (e) => {
+    e.stopPropagation();
+    if (state === 'loading' || (state === 'done' && !allowResync)) return;
+    setState('loading');
+    try {
+      await onSync();
+      setState('done');
+      if (allowResync) {
+        setTimeout(() => setState('idle'), 2500);
+      }
+    } catch (err) {
+      console.error(err);
+      setState('error');
+      alert(`Erreur de synchronisation Google Fit : ${err.message || err}`);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className={`gfit-item-btn gfit-item-${state}`}
+      onClick={handleClick}
+      disabled={state === 'loading' || (state === 'done' && !allowResync)}
+      title={state === 'done' ? 'Synchronisé avec Google Fit' : title}
+      aria-label={title}
+    >
+      {state === 'loading'
+        ? <span className="gfit-spinner" aria-hidden="true" />
+        : <img src={googleFitIcon} alt="" width={18} height={18} />}
+      {state === 'done' && <span className="gfit-check" aria-hidden="true">✓</span>}
+    </button>
+  );
+};
+
+export default GoogleFitItemButton;

--- a/src/components/GoogleFitSync.css
+++ b/src/components/GoogleFitSync.css
@@ -1,0 +1,126 @@
+/* Styles partagés pour la synchronisation Google Fit */
+
+.gfit-sync {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  margin: 12px 0;
+}
+
+.gfit-sync-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  color: #f4f4f5;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease, opacity 0.2s ease;
+}
+
+.gfit-sync-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.12);
+  transform: translateY(-1px);
+}
+
+.gfit-sync-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.gfit-sync-progress {
+  width: 100%;
+  max-width: 280px;
+  height: 4px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.12);
+  overflow: hidden;
+}
+
+.gfit-sync-bar {
+  height: 100%;
+  width: 40%;
+  border-radius: 4px;
+  background: #4285f4;
+  animation: gfit-indeterminate 1.1s infinite ease-in-out;
+}
+
+@keyframes gfit-indeterminate {
+  0% { transform: translateX(-120%); }
+  100% { transform: translateX(320%); }
+}
+
+.gfit-sync-result {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #34a853;
+}
+
+.gfit-sync-error {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #ef4444;
+  text-align: center;
+  max-width: 320px;
+}
+
+/* Bouton individuel par élément */
+.gfit-item-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.06);
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease;
+  flex-shrink: 0;
+}
+
+.gfit-item-btn:hover:not(:disabled) {
+  background: rgba(66, 133, 244, 0.22);
+  transform: scale(1.08);
+}
+
+.gfit-item-btn:disabled {
+  cursor: default;
+}
+
+.gfit-item-done {
+  background: rgba(52, 168, 83, 0.18);
+}
+
+.gfit-item-done .gfit-check {
+  position: absolute;
+  margin-top: -16px;
+  margin-left: 18px;
+  font-size: 0.7rem;
+  color: #34a853;
+  font-weight: 800;
+}
+
+.gfit-item-error {
+  background: rgba(239, 68, 68, 0.18);
+}
+
+.gfit-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  border-top-color: #4285f4;
+  border-radius: 50%;
+  animation: gfit-spin 0.7s linear infinite;
+}
+
+@keyframes gfit-spin {
+  to { transform: rotate(360deg); }
+}

--- a/src/components/GoogleFitSyncButton.jsx
+++ b/src/components/GoogleFitSyncButton.jsx
@@ -1,0 +1,65 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import googleFitIcon from '../icons/google-fit.svg';
+import './GoogleFitSync.css';
+
+/**
+ * Bouton de synchronisation Google Fit "en masse".
+ * @param {() => number} getUnsyncedCount - renvoie le nombre d'éléments non synchronisés.
+ * @param {() => Promise<{synced:number, failed:number, details:Array}>} onSync - lance la synchro.
+ * @param {string} noun / nounPlural - libellé de l'élément (ex: "séance" / "séances").
+ */
+const GoogleFitSyncButton = ({ getUnsyncedCount, onSync, noun = 'élément', nounPlural = 'éléments' }) => {
+  const [count, setCount] = useState(0);
+  const [syncing, setSyncing] = useState(false);
+  const [result, setResult] = useState(null);
+  const [error, setError] = useState(null);
+
+  const refresh = useCallback(() => setCount(getUnsyncedCount()), [getUnsyncedCount]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const handleClick = async () => {
+    if (syncing || count === 0) return;
+    setSyncing(true);
+    setResult(null);
+    setError(null);
+    try {
+      const res = await onSync();
+      setResult(res);
+      refresh();
+    } catch (err) {
+      setError(err.message || 'Erreur lors de la synchronisation');
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const label = syncing
+    ? 'Synchronisation…'
+    : count === 0
+      ? 'Tout est synchronisé avec Google Fit'
+      : `Synchroniser ${count} ${count > 1 ? nounPlural : noun} avec Google Fit`;
+
+  return (
+    <div className="gfit-sync">
+      <button
+        className="gfit-sync-btn"
+        onClick={handleClick}
+        disabled={syncing || count === 0}
+      >
+        <img src={googleFitIcon} alt="Google Fit" width={20} height={20} />
+        <span>{label}</span>
+      </button>
+      {syncing && <div className="gfit-sync-progress"><div className="gfit-sync-bar" /></div>}
+      {error && <p className="gfit-sync-error">{error}</p>}
+      {result && (
+        <p className="gfit-sync-result">
+          {result.synced} synchronisé{result.synced > 1 ? 's' : ''}
+          {result.failed > 0 ? `, ${result.failed} échec${result.failed > 1 ? 's' : ''}` : ''}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default GoogleFitSyncButton;

--- a/src/components/WeightTracker.jsx
+++ b/src/components/WeightTracker.jsx
@@ -15,6 +15,14 @@ import {
   deleteWeightRecord,
   getWeightStats
 } from '../services/WeightStorage';
+import GoogleFitSyncButton from './GoogleFitSyncButton';
+import GoogleFitItemButton from './GoogleFitItemButton';
+import {
+  getUnsyncedWeights,
+  syncAllWeights,
+  syncWeightToGoogleFit,
+  isSyncedWithGoogleFit
+} from '../services/GoogleFitSync';
 import './WeightTracker.css';
 
 // Composant Popup d'encouragement
@@ -298,6 +306,12 @@ function WeightTracker() {
       {weightRecords.length > 0 && (
         <div className="weight-history">
           <h3>{t('weight.history', { defaultValue: 'Historique des Pesées' })}</h3>
+          <GoogleFitSyncButton
+            getUnsyncedCount={() => getUnsyncedWeights().length}
+            onSync={syncAllWeights}
+            noun="pesée"
+            nounPlural="pesées"
+          />
           <div className="weight-records-list">
             {weightRecords.slice().reverse().map(record => (
               <div key={record.id} className="weight-record">
@@ -306,13 +320,20 @@ function WeightTracker() {
                   <div className="record-date">{formatDate(record.date)}</div>
                   {record.notes && <div className="record-notes">{record.notes}</div>}
                 </div>
-                <button 
-                  className="delete-record" 
-                  onClick={() => handleDeleteRecord(record.id)}
-                  aria-label="Supprimer"
-                >
-                  <Trash2 size={18} />
-                </button>
+                <div className="record-actions" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                  <GoogleFitItemButton
+                    synced={isSyncedWithGoogleFit('weight', record.id)}
+                    onSync={() => syncWeightToGoogleFit(record)}
+                    title="Synchroniser cette pesée avec Google Fit"
+                  />
+                  <button
+                    className="delete-record"
+                    onClick={() => handleDeleteRecord(record.id)}
+                    aria-label="Supprimer"
+                  >
+                    <Trash2 size={18} />
+                  </button>
+                </div>
               </div>
             ))}
           </div>

--- a/src/components/WorkoutCalendar.jsx
+++ b/src/components/WorkoutCalendar.jsx
@@ -3,6 +3,14 @@ import Calendar from 'react-calendar';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { getWorkoutHistory } from '../services/WorkoutStorage';
+import GoogleFitSyncButton from './GoogleFitSyncButton';
+import GoogleFitItemButton from './GoogleFitItemButton';
+import {
+  getUnsyncedWorkouts,
+  syncAllWorkouts,
+  syncWorkoutToGoogleFit,
+  isSyncedWithGoogleFit
+} from '../services/GoogleFitSync';
 
 // Importez le CSS par défaut de react-calendar
 import 'react-calendar/dist/Calendar.css';
@@ -72,7 +80,14 @@ function WorkoutCalendar() {
   return (
     <div className="workout-calendar-container workout-calendar-centered">
       <h2 className="calendar-title">Calendrier d'Entraînement</h2>
-      
+
+      <GoogleFitSyncButton
+        getUnsyncedCount={() => getUnsyncedWorkouts().length}
+        onSync={syncAllWorkouts}
+        noun="séance"
+        nounPlural="séances"
+      />
+
       <Calendar
         onChange={setValue}
         value={value}
@@ -90,6 +105,11 @@ function WorkoutCalendar() {
               <div className="workout-header">
                 <span className="workout-title">{workout.title}</span>
                 <span className="workout-time">{format(new Date(workout.date), 'HH:mm', { locale: fr })}</span>
+                <GoogleFitItemButton
+                  synced={isSyncedWithGoogleFit('workout', workout.id)}
+                  onSync={() => syncWorkoutToGoogleFit(workout)}
+                  title="Synchroniser cette séance avec Google Fit"
+                />
               </div>
               
               <div className="workout-stats">

--- a/src/services/GoogleFitService.js
+++ b/src/services/GoogleFitService.js
@@ -12,7 +12,8 @@ const PROJECT_NUMBER = CLIENT_ID.split('-')[0];
 
 const SCOPES = [
   'https://www.googleapis.com/auth/fitness.activity.write',
-  'https://www.googleapis.com/auth/fitness.body.write'
+  'https://www.googleapis.com/auth/fitness.body.write',
+  'https://www.googleapis.com/auth/fitness.nutrition.write'
 ].join(' ');
 
 const GIS_SRC = 'https://accounts.google.com/gsi/client';
@@ -119,6 +120,52 @@ class GoogleFitService {
     this.tokenExpiresAt = 0;
   }
 
+  // Construit l'ID déterministe d'une source de données "raw"
+  // (format imposé : type:dataType:projectNumber:manufacturer:model:uid:streamName).
+  buildDataSourceId(dataTypeName, streamName) {
+    return `raw:${dataTypeName}:${PROJECT_NUMBER}:ProjectFatLoss:web:1:${streamName}`;
+  }
+
+  // Crée la source de données si elle n'existe pas déjà (ignore l'erreur 409).
+  async ensureDataSource(dataTypeName, streamName) {
+    try {
+      await this.apiFetch('dataSources', 'POST', {
+        dataStreamName: streamName,
+        type: 'raw',
+        application: { name: 'Project Fat Loss' },
+        dataType: { name: dataTypeName },
+        device: {
+          manufacturer: 'ProjectFatLoss',
+          model: 'web',
+          type: 'unknown',
+          uid: '1',
+          version: '1'
+        }
+      });
+    } catch (error) {
+      // 409 Conflict = source déjà existante, ce qui est attendu.
+      if (!/\b409\b/.test(error.message)) throw error;
+    }
+  }
+
+  // Écrit un point instantané (startTime == endTime) dans un dataset.
+  async writeInstantPoint(dataTypeName, streamName, timestampMillis, value) {
+    const dataSourceId = this.buildDataSourceId(dataTypeName, streamName);
+    const ts = (BigInt(timestampMillis) * 1000000n).toString();
+    const datasetId = `${ts}-${ts}`;
+    await this.apiFetch(`dataSources/${dataSourceId}/datasets/${datasetId}`, 'PATCH', {
+      dataSourceId,
+      minStartTimeNs: ts,
+      maxEndTimeNs: ts,
+      point: [{
+        dataTypeName,
+        startTimeNanos: ts,
+        endTimeNanos: ts,
+        value
+      }]
+    });
+  }
+
   // Appel REST authentifié vers l'API Fitness.
   async apiFetch(path, method, body) {
     const token = await this.signIn();
@@ -151,33 +198,11 @@ class GoogleFitService {
     const startTimeNanos = (BigInt(startTimeMillis) * 1000000n).toString();
     const endTimeNanos = (BigInt(endTimeMillis) * 1000000n).toString();
 
-    // ID déterministe de la source de données "raw" (format imposé par l'API) :
-    // type:dataType:projectNumber:manufacturer:model:uid:streamName
-    const dataSourceId = `raw:com.google.calories.expended:${PROJECT_NUMBER}:ProjectFatLoss:web:1:ProjectFatLossCalories`;
+    const dataSourceId = this.buildDataSourceId('com.google.calories.expended', 'ProjectFatLossCalories');
 
     try {
       // 1. Créer la source de données (ignore l'erreur 409 si elle existe déjà).
-      try {
-        await this.apiFetch('dataSources', 'POST', {
-          dataStreamName: 'ProjectFatLossCalories',
-          type: 'raw',
-          application: { name: 'Project Fat Loss' },
-          dataType: {
-            name: 'com.google.calories.expended',
-            field: [{ name: 'calories', format: 'floatPoint' }]
-          },
-          device: {
-            manufacturer: 'ProjectFatLoss',
-            model: 'web',
-            type: 'unknown',
-            uid: '1',
-            version: '1'
-          }
-        });
-      } catch (error) {
-        // 409 Conflict = source déjà existante, ce qui est attendu.
-        if (!/\b409\b/.test(error.message)) throw error;
-      }
+      await this.ensureDataSource('com.google.calories.expended', 'ProjectFatLossCalories');
 
       // 2. Écrire le point de calories dépensées dans le dataset.
       const datasetId = `${startTimeNanos}-${endTimeNanos}`;
@@ -211,6 +236,47 @@ class GoogleFitService {
       return true;
     } catch (error) {
       console.error('Erreur lors de l\'ajout de l\'activité:', error);
+      throw error;
+    }
+  }
+
+  // Enregistre une pesée (poids corporel) dans Google Fit.
+  async addWeight(weightKg, timestampMillis = Date.now()) {
+    if (!this.isInitialized) await this.init();
+
+    try {
+      await this.ensureDataSource('com.google.weight', 'ProjectFatLossWeight');
+      await this.writeInstantPoint('com.google.weight', 'ProjectFatLossWeight', timestampMillis, [
+        { fpVal: weightKg }
+      ]);
+      return true;
+    } catch (error) {
+      console.error('Erreur lors de l\'ajout du poids:', error);
+      throw error;
+    }
+  }
+
+  // Enregistre un résumé nutritionnel (calories + macros) dans Google Fit.
+  async addNutrition(nutrition, timestampMillis = Date.now()) {
+    if (!this.isInitialized) await this.init();
+
+    try {
+      await this.ensureDataSource('com.google.nutrition', 'ProjectFatLossNutrition');
+      await this.writeInstantPoint('com.google.nutrition', 'ProjectFatLossNutrition', timestampMillis, [
+        {
+          mapVal: [
+            { key: 'calories', value: { fpVal: nutrition.calories || 0 } },
+            { key: 'protein', value: { fpVal: nutrition.protein || 0 } },
+            { key: 'fat.total', value: { fpVal: nutrition.fat || 0 } },
+            { key: 'carbs.total', value: { fpVal: nutrition.carbs || 0 } }
+          ]
+        },
+        { intVal: 1 }, // meal_type : 1 = inconnu (résumé journalier)
+        { stringVal: 'Résumé journalier Project Fat Loss' }
+      ]);
+      return true;
+    } catch (error) {
+      console.error('Erreur lors de l\'ajout de la nutrition:', error);
       throw error;
     }
   }

--- a/src/services/GoogleFitService.js
+++ b/src/services/GoogleFitService.js
@@ -18,6 +18,33 @@ const SCOPES = [
 
 const GIS_SRC = 'https://accounts.google.com/gsi/client';
 
+// Erreur d'appel à l'API Fitness, porteuse du code HTTP pour un test fiable
+// (plutôt qu'un parsing de chaîne).
+class GoogleFitApiError extends Error {
+  constructor(message, status, body) {
+    super(message);
+    this.name = 'GoogleFitApiError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+// Construit un message d'erreur concis et lisible à partir d'une réponse d'erreur
+// de l'API (qui renvoie souvent un gros JSON), pour l'affichage utilisateur.
+function describeApiError(status, rawBody) {
+  let message;
+  try {
+    const parsed = JSON.parse(rawBody);
+    message = parsed?.error?.message || parsed?.error_description || parsed?.error;
+  } catch {
+    // Le corps n'est pas du JSON : on le garde tel quel s'il est court.
+  }
+  if (!message) {
+    message = rawBody && rawBody.length <= 200 ? rawBody : `Erreur HTTP ${status}`;
+  }
+  return `Google Fit (${status}) : ${message}`;
+}
+
 class GoogleFitService {
   constructor() {
     this.tokenClient = null;
@@ -30,7 +57,7 @@ class GoogleFitService {
     if (this.isInitialized) return;
 
     try {
-      await this.loadScript(GIS_SRC);
+      await this.loadScript(GIS_SRC, () => !!(window.google && window.google.accounts && window.google.accounts.oauth2));
 
       if (!window.google || !window.google.accounts || !window.google.accounts.oauth2) {
         throw new Error('Google Identity Services indisponible (script non chargé). Vérifiez votre connexion réseau ou un bloqueur de scripts.');
@@ -50,8 +77,17 @@ class GoogleFitService {
     }
   }
 
-  loadScript(src) {
+  // Charge un script externe. `isReady` (optionnel) est un prédicat indiquant que
+  // la lib est déjà disponible : il évite tout blocage si le script a été injecté
+  // ailleurs (sans data-loaded) et a déjà fini de charger — l'événement `load`
+  // ne se redéclenchant pas dans ce cas.
+  loadScript(src, isReady) {
     return new Promise((resolve, reject) => {
+      if (typeof isReady === 'function' && isReady()) {
+        resolve();
+        return;
+      }
+
       const existing = document.querySelector(`script[src="${src}"]`);
       if (existing) {
         if (existing.dataset.loaded === 'true') {
@@ -144,14 +180,23 @@ class GoogleFitService {
       });
     } catch (error) {
       // 409 Conflict = source déjà existante, ce qui est attendu.
-      if (!/\b409\b/.test(error.message)) throw error;
+      if (error.status !== 409) throw error;
     }
+  }
+
+  // Convertit des millisecondes en nanosecondes (chaîne) après validation.
+  // Les nanosecondes dépassent Number.MAX_SAFE_INTEGER : on passe par BigInt.
+  toNanos(timestampMillis) {
+    if (!Number.isFinite(timestampMillis)) {
+      throw new Error('Horodatage invalide pour Google Fit.');
+    }
+    return (BigInt(timestampMillis) * 1000000n).toString();
   }
 
   // Écrit un point instantané (startTime == endTime) dans un dataset.
   async writeInstantPoint(dataTypeName, streamName, timestampMillis, value) {
     const dataSourceId = this.buildDataSourceId(dataTypeName, streamName);
-    const ts = (BigInt(timestampMillis) * 1000000n).toString();
+    const ts = this.toNanos(timestampMillis);
     const datasetId = `${ts}-${ts}`;
     await this.apiFetch(`dataSources/${dataSourceId}/datasets/${datasetId}`, 'PATCH', {
       dataSourceId,
@@ -180,7 +225,7 @@ class GoogleFitService {
 
     if (!response.ok) {
       const detail = await response.text();
-      throw new Error(`API Google Fit ${response.status}: ${detail}`);
+      throw new GoogleFitApiError(describeApiError(response.status, detail), response.status, detail);
     }
 
     return response.status === 204 ? null : response.json();
@@ -193,10 +238,10 @@ class GoogleFitService {
     const durationMillis = activity.duration || 3600000; // Durée par défaut 1h
     const endTimeMillis = startTimeMillis + durationMillis;
 
-    // Les nanosecondes dépassent Number.MAX_SAFE_INTEGER : on utilise BigInt
-    // puis on sérialise en chaîne (l'API accepte les int64 sous forme de string).
-    const startTimeNanos = (BigInt(startTimeMillis) * 1000000n).toString();
-    const endTimeNanos = (BigInt(endTimeMillis) * 1000000n).toString();
+    // toNanos valide les horodatages (lève une erreur si startTime est invalide)
+    // et sérialise en chaîne (l'API accepte les int64 sous forme de string).
+    const startTimeNanos = this.toNanos(startTimeMillis);
+    const endTimeNanos = this.toNanos(endTimeMillis);
 
     const dataSourceId = this.buildDataSourceId('com.google.calories.expended', 'ProjectFatLossCalories');
 

--- a/src/services/GoogleFitSync.js
+++ b/src/services/GoogleFitSync.js
@@ -1,0 +1,131 @@
+// Couche de synchronisation Google Fit pour l'historique (séances, poids, nutrition).
+//
+// L'état "déjà synchronisé" est conservé dans une clé localStorage dédiée afin de
+// NE PAS modifier les enregistrements métier (et donc ne pas déclencher les push
+// Supabase associés). On évite ainsi les doublons côté Google Fit.
+import GoogleFitService from './GoogleFitService';
+import { getWorkoutHistory } from './WorkoutStorage';
+import { getWeightHistory } from './WeightStorage';
+import { getNutritionSummary } from '../data/foodDatabase';
+
+const SYNCED_KEY = 'pfl_googlefit_synced';
+
+// Durée par défaut d'une séance enregistrée depuis l'historique (45 min).
+const DEFAULT_WORKOUT_DURATION_MS = 45 * 60 * 1000;
+
+function getSyncedMap() {
+  try {
+    return JSON.parse(localStorage.getItem(SYNCED_KEY) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function markSynced(category, id) {
+  const map = getSyncedMap();
+  if (!map[category]) map[category] = {};
+  map[category][String(id)] = Date.now();
+  localStorage.setItem(SYNCED_KEY, JSON.stringify(map));
+}
+
+export function isSyncedWithGoogleFit(category, id) {
+  const map = getSyncedMap();
+  return !!(map[category] && map[category][String(id)]);
+}
+
+// ── Synchronisation d'un élément unique ──────────────────────────────
+
+export async function syncWorkoutToGoogleFit(workout) {
+  const endTime = new Date(workout.date).getTime();
+  await GoogleFitService.addActivity({
+    activityType: 97, // Strength Training
+    name: `Project Fat Loss - ${workout.title || 'Entraînement'}`,
+    description: `Séance de musculation. Poids total soulevé : ${workout.weightLifted || 0} kg.`,
+    startTime: endTime - DEFAULT_WORKOUT_DURATION_MS,
+    duration: DEFAULT_WORKOUT_DURATION_MS,
+    calories: workout.calories || 0
+  });
+  markSynced('workout', workout.id);
+}
+
+export async function syncWeightToGoogleFit(record) {
+  await GoogleFitService.addWeight(record.weight, new Date(record.date).getTime());
+  markSynced('weight', record.id);
+}
+
+export async function syncNutritionDayToGoogleFit(dateStr) {
+  const summary = getNutritionSummary(dateStr);
+  // Horodatage à midi pour rattacher le résumé à la bonne journée.
+  const timestamp = new Date(`${dateStr}T12:00:00`).getTime();
+  await GoogleFitService.addNutrition(summary, timestamp);
+  markSynced('nutrition', dateStr);
+}
+
+// ── Synchronisation en masse ─────────────────────────────────────────
+
+// Exécute `syncOne` sur chaque élément non encore synchronisé.
+// Retourne { synced, failed, details }.
+async function syncMany(items, syncOne, getId, getLabel) {
+  const result = { synced: 0, failed: 0, details: [] };
+  for (const item of items) {
+    try {
+      await syncOne(item);
+      result.synced += 1;
+      result.details.push({ label: getLabel(item), status: 'success' });
+    } catch (error) {
+      result.failed += 1;
+      result.details.push({ label: getLabel(item), status: 'failed', reason: error.message });
+    }
+  }
+  return result;
+}
+
+export function getUnsyncedWorkouts() {
+  return getWorkoutHistory().filter(w => !isSyncedWithGoogleFit('workout', w.id));
+}
+
+export function getUnsyncedWeights() {
+  return getWeightHistory().filter(r => !isSyncedWithGoogleFit('weight', r.id));
+}
+
+export async function syncAllWorkouts() {
+  return syncMany(
+    getUnsyncedWorkouts(),
+    syncWorkoutToGoogleFit,
+    w => w.id,
+    w => `${w.title || 'Entraînement'} (${w.displayDate || ''})`
+  );
+}
+
+export async function syncAllWeights() {
+  return syncMany(
+    getUnsyncedWeights(),
+    syncWeightToGoogleFit,
+    r => r.id,
+    r => `${r.weight} kg`
+  );
+}
+
+function getNutritionLogDates() {
+  try {
+    return Object.keys(JSON.parse(localStorage.getItem('pfl_nutrition_logs') || '{}'));
+  } catch {
+    return [];
+  }
+}
+
+// Jours nutritionnels enregistrés (avec au moins une calorie) non encore synchronisés.
+export function getUnsyncedNutritionDays() {
+  return getNutritionLogDates().filter(
+    d => !isSyncedWithGoogleFit('nutrition', d) && getNutritionSummary(d).calories > 0
+  );
+}
+
+export async function syncAllNutritionDays() {
+  return syncMany(
+    getUnsyncedNutritionDays(),
+    syncNutritionDayToGoogleFit,
+    d => d,
+    d => d
+  );
+}


### PR DESCRIPTION
## Contexte

La PR #11 a été mergée alors qu'elle ne contenait que le **1er commit** (migration GIS). Les boutons Google Fit sur les écrans Historique / Poids / Calories ont été poussés ensuite et ne sont donc **pas encore dans `main`** — d'où leur absence sur le site déployé. Cette PR amène les 2 commits manquants.

## Changements

Synchronisation Google Fit **depuis l'historique**, en masse + par élément, sur 3 écrans (Google Fit uniquement, Strava non activé) :

| Écran | Bouton global (masse) | Bouton par item |
|---|---|---|
| **Historique** (séances) | « Synchroniser N séances » | icône Fit sur chaque carte |
| **Poids** | « Synchroniser N pesées » | icône Fit sur chaque pesée |
| **Calories** (nutrition) | « Synchroniser N jours » | bouton « ce jour » (re-synchronisable) |

- **`GoogleFitService`** : ajout de `addWeight` (`com.google.weight`) et `addNutrition` (`com.google.nutrition` + macros), helpers génériques `ensureDataSource` / `writeInstantPoint` / `buildDataSourceId`, scope `fitness.nutrition.write`.
- **`GoogleFitSync.js`** (nouveau) : couche de sync qui suit l'état déjà-synchronisé dans une clé localStorage dédiée (`pfl_googlefit_synced`) — sans muter les données métier ni déclencher de push Supabase. Sync unitaire + en masse pour séances, pesées et jours.
- **`GoogleFitSyncButton`** (masse) + **`GoogleFitItemButton`** (par élément) réutilisables.
- Câblage dans `WorkoutCalendar`, `WeightTracker`, `CalorieCounter`.

### Corrections suite à la revue de code (commit 2)
- `apiFetch` lève une `GoogleFitApiError` porteuse du code HTTP ; `ensureDataSource` teste `error.status === 409` (au lieu d'un parsing de chaîne).
- `describeApiError` normalise les réponses d'erreur (JSON volumineux) en message concis pour l'utilisateur.
- `toNanos` valide les horodatages avant la conversion `BigInt` (évite un `RangeError`).
- `loadScript` accepte un prédicat `isReady` pour résoudre immédiatement si la lib est déjà chargée (évite un blocage).

## ⚠️ Côté Google Cloud Console
Le scope `fitness.nutrition.write` a été ajouté : il faudra **ré-autoriser** (le popup Google redemandera le consentement). Vérifier aussi que le compte est dans les **utilisateurs de test** si l'app OAuth est en mode « Testing ».

## Tests
- `npm run build` ✅

https://claude.ai/code/session_01UaiQKFeCaSi5XWxdSTsbb3

---
_Generated by [Claude Code](https://claude.ai/code/session_01UaiQKFeCaSi5XWxdSTsbb3)_

## Summary by Sourcery

Add Google Fit synchronization from historical data for workouts, weight, and nutrition, including reusable UI controls and a sync layer that tracks already-synced items locally to prevent duplicates.

New Features:
- Enable Google Fit sync for workout history with per-session and bulk sync actions from the calendar view.
- Enable Google Fit sync for weight history with per-entry and bulk sync actions from the weight tracker.
- Enable Google Fit sync for daily nutrition summaries with per-day and bulk sync actions from the calorie counter, including support for calories and macros in Google Fit.
- Extend the Google Fit service to write body weight and nutrition data using the appropriate Fitness data types and scopes.

Enhancements:
- Introduce a Google Fit sync abstraction that uses localStorage to track already-synchronized workouts, weigh-ins, and nutrition days without mutating business records.
- Add shared Google Fit synchronization UI components and styles for bulk and per-item sync, including progress and status feedback.
- Refactor Google Fit service to share data source and timestamp handling, and to improve script loading behavior when GIS is already present.
- Improve API error reporting for Google Fit calls with structured HTTP error handling and user-friendly messages.