### PR TITLE
Affiner la synchronisation Google Fit (revue de code)

### DIFF
--- a/src/components/GoogleFitItemButton.jsx
+++ b/src/components/GoogleFitItemButton.jsx
@@ -4,18 +4,23 @@ import './GoogleFitSync.css';
 
 /**
  * Petit bouton de synchronisation Google Fit pour un élément individuel.
+ * Composant présentationnel : la gestion de l'erreur est déléguée au parent
+ * via `onError` (l'erreur est aussi reflétée dans le tooltip du bouton).
  * @param {boolean} synced - true si déjà synchronisé (état initial).
  * @param {() => Promise<void>} onSync - lance la synchro de l'élément.
+ * @param {(error: Error) => void} [onError] - notifié en cas d'échec.
  * @param {boolean} allowResync - si true, le bouton reste cliquable après succès
  *   (utile pour la nutrition d'une journée encore modifiable).
  */
-const GoogleFitItemButton = ({ synced = false, onSync, allowResync = false, title = 'Synchroniser avec Google Fit' }) => {
+const GoogleFitItemButton = ({ synced = false, onSync, onError, allowResync = false, title = 'Synchroniser avec Google Fit' }) => {
   const [state, setState] = useState(synced ? 'done' : 'idle'); // idle | loading | done | error
+  const [errorMsg, setErrorMsg] = useState('');
 
   const handleClick = async (e) => {
     e.stopPropagation();
     if (state === 'loading' || (state === 'done' && !allowResync)) return;
     setState('loading');
+    setErrorMsg('');
     try {
       await onSync();
       setState('done');
@@ -25,9 +30,16 @@ const GoogleFitItemButton = ({ synced = false, onSync, allowResync = false, titl
     } catch (err) {
       console.error(err);
       setState('error');
-      alert(`Erreur de synchronisation Google Fit : ${err.message || err}`);
+      setErrorMsg(err.message || String(err));
+      if (typeof onError === 'function') onError(err);
     }
   };
+
+  const tooltip = state === 'done'
+    ? 'Synchronisé avec Google Fit'
+    : state === 'error'
+      ? `Échec : ${errorMsg}`
+      : title;
 
   return (
     <button
@@ -35,7 +47,7 @@ const GoogleFitItemButton = ({ synced = false, onSync, allowResync = false, titl
       className={`gfit-item-btn gfit-item-${state}`}
       onClick={handleClick}
       disabled={state === 'loading' || (state === 'done' && !allowResync)}
-      title={state === 'done' ? 'Synchronisé avec Google Fit' : title}
+      title={tooltip}
       aria-label={title}
     >
       {state === 'loading'

--- a/src/services/GoogleFitSync.js
+++ b/src/services/GoogleFitSync.js
@@ -9,23 +9,38 @@ import { getWeightHistory } from './WeightStorage';
 import { getNutritionSummary } from '../data/foodDatabase';
 
 const SYNCED_KEY = 'pfl_googlefit_synced';
+const NUTRITION_LOGS_KEY = 'pfl_nutrition_logs';
 
 // Durée par défaut d'une séance enregistrée depuis l'historique (45 min).
 const DEFAULT_WORKOUT_DURATION_MS = 45 * 60 * 1000;
 
-function getSyncedMap() {
+// Accès localStorage protégé pour les contextes non-navigateur (SSR, tests).
+function getStorage() {
+  if (typeof window === 'undefined' || !window.localStorage) return null;
+  return window.localStorage;
+}
+
+function readJSON(key, fallback) {
+  const storage = getStorage();
+  if (!storage) return fallback;
   try {
-    return JSON.parse(localStorage.getItem(SYNCED_KEY) || '{}');
+    return JSON.parse(storage.getItem(key) || JSON.stringify(fallback));
   } catch {
-    return {};
+    return fallback;
   }
 }
 
+function getSyncedMap() {
+  return readJSON(SYNCED_KEY, {});
+}
+
 function markSynced(category, id) {
+  const storage = getStorage();
+  if (!storage) return;
   const map = getSyncedMap();
   if (!map[category]) map[category] = {};
   map[category][String(id)] = Date.now();
-  localStorage.setItem(SYNCED_KEY, JSON.stringify(map));
+  storage.setItem(SYNCED_KEY, JSON.stringify(map));
 }
 
 export function isSyncedWithGoogleFit(category, id) {
@@ -65,7 +80,7 @@ export async function syncNutritionDayToGoogleFit(dateStr) {
 
 // Exécute `syncOne` sur chaque élément non encore synchronisé.
 // Retourne { synced, failed, details }.
-async function syncMany(items, syncOne, getId, getLabel) {
+async function syncMany(items, syncOne, getLabel) {
   const result = { synced: 0, failed: 0, details: [] };
   for (const item of items) {
     try {
@@ -92,7 +107,6 @@ export async function syncAllWorkouts() {
   return syncMany(
     getUnsyncedWorkouts(),
     syncWorkoutToGoogleFit,
-    w => w.id,
     w => `${w.title || 'Entraînement'} (${w.displayDate || ''})`
   );
 }
@@ -101,17 +115,12 @@ export async function syncAllWeights() {
   return syncMany(
     getUnsyncedWeights(),
     syncWeightToGoogleFit,
-    r => r.id,
     r => `${r.weight} kg`
   );
 }
 
 function getNutritionLogDates() {
-  try {
-    return Object.keys(JSON.parse(localStorage.getItem('pfl_nutrition_logs') || '{}'));
-  } catch {
-    return [];
-  }
+  return Object.keys(readJSON(NUTRITION_LOGS_KEY, {}));
 }
 
 // Jours nutritionnels enregistrés (avec au moins une calorie) non encore synchronisés.
@@ -125,7 +134,6 @@ export async function syncAllNutritionDays() {
   return syncMany(
     getUnsyncedNutritionDays(),
     syncNutritionDayToGoogleFit,
-    d => d,
     d => d
   );
 }


### PR DESCRIPTION
## Corrections suite à la revue de code

### `GoogleFitSync.js`
- **Accès localStorage protégé** : ajout de `getStorage()` (garde `typeof window !== 'undefined'`) et d'un helper `readJSON`, utilisés par `getSyncedMap`, `markSynced` et `getNutritionLogDates`. Évite tout crash en contexte non-navigateur (SSR, tests).
- **Suppression du paramètre `getId` inutilisé** de `syncMany`, ainsi que des arguments correspondants dans `syncAllWorkouts`, `syncAllWeights` et `syncAllNutritionDays`.
- Constante `NUTRITION_LOGS_KEY` introduite pour la clé de logs nutrition.

### `GoogleFitItemButton.jsx`
- **Suppression de l'`alert` intrusif** au profit d'un callback optionnel **`onError`** : le composant redevient présentationnel, le parent peut décider de l'affichage.
- L'erreur est aussi reflétée dans le **tooltip** du bouton (`title="Échec : …"`) et l'état visuel rouge existant est conservé.

## Tests
- `npm run build` ✅

https://claude.ai/code/session_01UaiQKFeCaSi5XWxdSTsbb3

---
_Generated by [Claude Code](https://claude.ai/code/session_01UaiQKFeCaSi5XWxdSTsbb3)_

## Summary by Sourcery

Improve robustness of Google Fit synchronization and error handling for individual sync buttons.

Bug Fixes:
- Guard localStorage access through a helper to avoid crashes in non-browser contexts and when parsing stored data.
- Replace an intrusive alert on Google Fit sync failure with non-blocking error reporting and a tooltip message.

Enhancements:
- Introduce shared helpers and constants for reading JSON from localStorage, including a dedicated nutrition logs key, and reuse them across sync utilities.
- Simplify the generic sync helper by removing an unused identifier callback and updating its callers accordingly.
- Expose an optional onError callback from the Google Fit item button so parents can handle sync failures while preserving existing visual states and tooltips.