### PR TITLE
Corriger l'icône Google Fit manquante et l'erreur 403 de session

### DIFF
--- a/src/icons/google-fit.svg
+++ b/src/icons/google-fit.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-label="Google Fit">
+  <path fill="#EA4335" d="M12 12 2 12 6 6z"/>
+  <path fill="#4285F4" d="M12 12 12 2 18 6z"/>
+  <path fill="#34A853" d="M12 12 22 12 18 18z"/>
+  <path fill="#FBBC04" d="M12 12 12 22 6 18z"/>
+</svg>

--- a/src/services/GoogleFitService.js
+++ b/src/services/GoogleFitService.js
@@ -271,9 +271,10 @@ class GoogleFitService {
         description: activity.description,
         startTimeMillis,
         endTimeMillis,
+        // Pas de packageName : un client web/REST n'est pas une app Android de
+        // confiance, et Google Fit rejette alors la session (403 "un-trusted source").
         application: {
-          name: 'Project Fat Loss',
-          packageName: 'com.projectfatloss'
+          name: 'Project Fat Loss'
         },
         activityType: activity.activityType
       });


### PR DESCRIPTION
## Deux bugs constatés en production

### 1. Icône Google Fit invisible
`src/icons/google-fit.svg` était un **fichier vide (0 octet)** → image cassée dans tous les boutons de synchronisation (`GoogleFitSyncButton`, `GoogleFitItemButton`). Ajout d'un vrai logo SVG 4 couleurs (bleu/rouge/jaune/vert).

### 2. Erreur 403 à la synchronisation d'une séance
Message remonté (grâce au nouveau reporting d'erreur) :
> `Google Fit (403) : Application package name (com.projectfatloss) provided by un-trusted source.`

La création de session envoyait `application.packageName: 'com.projectfatloss'`. Or un **client web/REST n'est pas une app Android de confiance** : Google Fit rejette alors la session. Correction : on n'envoie plus que `application.name`.

## Notes
- Ces correctifs touchent des fichiers **distincts** de la PR #15 (corrections de revue) — pas de conflit.
- Basé sur `main` pour être déployable immédiatement après merge.

## Tests
- `npm run build` ✅

https://claude.ai/code/session_01UaiQKFeCaSi5XWxdSTsbb3

---
_Generated by [Claude Code](https://claude.ai/code/session_01UaiQKFeCaSi5XWxdSTsbb3)_

## Summary by Sourcery

Fix Google Fit integration issues affecting UI icons and session creation with the external API.

Bug Fixes:
- Restore the Google Fit SVG icon so it displays correctly in synchronization buttons.
- Adjust Google Fit session creation payload to omit the Android package name from web/REST clients, preventing 403 "un-trusted source" errors.