### PR TITLE
Afficher l'icône Google Fit en SVG inline (robuste au cache PWA)

### DIFF
--- a/src/components/GoogleFitButton.jsx
+++ b/src/components/GoogleFitButton.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import GoogleFitService from '../services/GoogleFitService';
+import GoogleFitIcon from './GoogleFitIcon';
 import './GoogleFitButton.css';
 
 const GoogleFitButton = ({ exercise }) => {
@@ -44,12 +45,7 @@ const GoogleFitButton = ({ exercise }) => {
       onClick={syncWithGoogleFit}
       disabled={isLoading}
     >
-      <img 
-        src="/icons/google-fit.svg" 
-        alt="Google Fit"
-        width="24"
-        height="24"
-      />
+      <GoogleFitIcon size={24} />
       {isLoading ? 'Synchronisation...' : 'Ajouter à Google Fit'}
     </button>
   );

--- a/src/components/GoogleFitIcon.jsx
+++ b/src/components/GoogleFitIcon.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+/**
+ * Logo Google Fit en SVG inline (4 couleurs).
+ * Inline volontairement (plutôt qu'un <img src=...svg>) pour ne pas dépendre
+ * d'un asset susceptible d'être mis en cache de façon obsolète par le service
+ * worker de la PWA — l'icône fait partie du bundle JS.
+ */
+const GoogleFitIcon = ({ size = 20, className, title = 'Google Fit' }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    className={className}
+    role="img"
+    aria-label={title}
+  >
+    <path fill="#EA4335" d="M12 12 2 12 6 6z" />
+    <path fill="#4285F4" d="M12 12 12 2 18 6z" />
+    <path fill="#34A853" d="M12 12 22 12 18 18z" />
+    <path fill="#FBBC04" d="M12 12 12 22 6 18z" />
+  </svg>
+);
+
+export default GoogleFitIcon;

--- a/src/components/GoogleFitItemButton.jsx
+++ b/src/components/GoogleFitItemButton.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import googleFitIcon from '../icons/google-fit.svg';
+import GoogleFitIcon from './GoogleFitIcon';
 import './GoogleFitSync.css';
 
 /**
@@ -52,7 +52,7 @@ const GoogleFitItemButton = ({ synced = false, onSync, onError, allowResync = fa
     >
       {state === 'loading'
         ? <span className="gfit-spinner" aria-hidden="true" />
-        : <img src={googleFitIcon} alt="" width={18} height={18} />}
+        : <GoogleFitIcon size={18} />}
       {state === 'done' && <span className="gfit-check" aria-hidden="true">✓</span>}
     </button>
   );

--- a/src/components/GoogleFitSyncButton.jsx
+++ b/src/components/GoogleFitSyncButton.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import googleFitIcon from '../icons/google-fit.svg';
+import GoogleFitIcon from './GoogleFitIcon';
 import './GoogleFitSync.css';
 
 /**
@@ -47,7 +47,7 @@ const GoogleFitSyncButton = ({ getUnsyncedCount, onSync, noun = 'élément', nou
         onClick={handleClick}
         disabled={syncing || count === 0}
       >
-        <img src={googleFitIcon} alt="Google Fit" width={20} height={20} />
+        <GoogleFitIcon size={20} />
         <span>{label}</span>
       </button>
       {syncing && <div className="gfit-sync-progress"><div className="gfit-sync-bar" /></div>}


### PR DESCRIPTION
## Problème

L'icône Google Fit ne s'affichait toujours pas, malgré un `src/icons/google-fit.svg` désormais valide. Cause : c'est une **PWA avec service worker** (`vite-plugin-pwa`, précache de tous les `.svg`). Un ``&lt;img src=…svg&gt;`` dépend du cache d'asset du SW, et le bundle servi pointait encore vers la version vide/obsolète.

## Solution

Rendre l'icône **indépendante de tout asset** en l'intégrant en **SVG inline** dans un composant React (elle fait alors partie du bundle JS, plus rien à mettre en cache séparément).

- Nouveau composant **`GoogleFitIcon`** (logo SVG inline 4 couleurs, prop `size`).
- Remplacement des `<img>` par `<GoogleFitIcon>` dans :
  - `GoogleFitSyncButton` (bouton de masse)
  - `GoogleFitItemButton` (bouton par élément)
  - `GoogleFitButton` (bouton par exercice — qui pointait en plus vers `/icons/google-fit.svg`, chemin **cassé** sous la base `/projectfatloss/`)

La PWA est en `registerType: 'autoUpdate'` : le nouveau service worker s'activera automatiquement au prochain chargement.

## Tests
- `npm run build` ✅

https://claude.ai/code/session_01UaiQKFeCaSi5XWxdSTsbb3

---
_Generated by [Claude Code](https://claude.ai/code/session_01UaiQKFeCaSi5XWxdSTsbb3)_

## Summary by Sourcery

Inline the Google Fit icon as a reusable React component to avoid PWA service worker caching issues and ensure the logo displays reliably across all related buttons.

New Features:
- Introduce a reusable GoogleFitIcon React component rendering the Google Fit logo as inline SVG with configurable size.

Bug Fixes:
- Fix missing or outdated Google Fit icon caused by PWA service worker caching of the SVG asset by embedding the icon directly in the JS bundle.

Enhancements:
- Standardize Google Fit button visuals by replacing img-based icons with the shared inline SVG component across exercise, item, and bulk sync buttons.