### PR TITLE
Google Fit : séances en « Musculation » + synchro du cardio

### DIFF
--- a/src/components/CardioTracker.jsx
+++ b/src/components/CardioTracker.jsx
@@ -7,6 +7,14 @@ import {
   getCardioStats,
 } from '../services/CardioStorage';
 import { getWeightHistory } from '../services/WeightStorage';
+import GoogleFitSyncButton from './GoogleFitSyncButton';
+import GoogleFitItemButton from './GoogleFitItemButton';
+import {
+  getUnsyncedCardio,
+  syncAllCardio,
+  syncCardioToGoogleFit,
+  isSyncedWithGoogleFit
+} from '../services/GoogleFitSync';
 import './CardioTracker.css';
 
 // MET approximatifs : marche ~3.5, vélo ~7.5
@@ -129,6 +137,13 @@ const CardioTracker = () => {
         </button>
       </form>
 
+      <GoogleFitSyncButton
+        getUnsyncedCount={() => getUnsyncedCardio().length}
+        onSync={syncAllCardio}
+        noun="séance cardio"
+        nounPlural="séances cardio"
+      />
+
       <div className="cardio-list">
         {sessions.length === 0 && <p className="cardio-empty">Aucune séance enregistrée.</p>}
         {sessions.map((s) => (
@@ -147,6 +162,11 @@ const CardioTracker = () => {
                 {s.calories != null && <span className="cardio-cal">{Math.round(s.calories)} kcal</span>}
               </div>
             </div>
+            <GoogleFitItemButton
+              synced={isSyncedWithGoogleFit('cardio', s.id)}
+              onSync={() => syncCardioToGoogleFit(s)}
+              title="Synchroniser cette séance cardio avec Google Fit"
+            />
             <button className="cardio-del" onClick={() => handleDelete(s.id)} aria-label="Supprimer">
               <Trash2 size={16} />
             </button>

--- a/src/services/GoogleFitSync.js
+++ b/src/services/GoogleFitSync.js
@@ -6,6 +6,7 @@
 import GoogleFitService from './GoogleFitService';
 import { getWorkoutHistory } from './WorkoutStorage';
 import { getWeightHistory } from './WeightStorage';
+import { getCardioSessions } from './CardioStorage';
 import { getNutritionSummary } from '../data/foodDatabase';
 
 const SYNCED_KEY = 'pfl_googlefit_synced';
@@ -68,6 +69,22 @@ export async function syncWeightToGoogleFit(record) {
   markSynced('weight', record.id);
 }
 
+export async function syncCardioToGoogleFit(session) {
+  const endTime = new Date(session.date).getTime();
+  // duration est en minutes ; défaut 30 min si non renseignée.
+  const durationMs = (session.duration ? session.duration : 30) * 60 * 1000;
+  const isBike = session.type === 'bike';
+  await GoogleFitService.addActivity({
+    activityType: isBike ? 1 : 7, // 1 = Vélo, 7 = Marche
+    name: `Project Fat Loss - ${isBike ? 'Vélo' : 'Marche'}`,
+    description: `Séance cardio${session.distance ? ` — ${session.distance} km` : ''}.`,
+    startTime: endTime - durationMs,
+    duration: durationMs,
+    calories: session.calories || 0
+  });
+  markSynced('cardio', session.id);
+}
+
 export async function syncNutritionDayToGoogleFit(dateStr) {
   const summary = getNutritionSummary(dateStr);
   // Horodatage à midi pour rattacher le résumé à la bonne journée.
@@ -103,6 +120,10 @@ export function getUnsyncedWeights() {
   return getWeightHistory().filter(r => !isSyncedWithGoogleFit('weight', r.id));
 }
 
+export function getUnsyncedCardio() {
+  return getCardioSessions().filter(s => !isSyncedWithGoogleFit('cardio', s.id));
+}
+
 export async function syncAllWorkouts() {
   return syncMany(
     getUnsyncedWorkouts(),
@@ -116,6 +137,14 @@ export async function syncAllWeights() {
     getUnsyncedWeights(),
     syncWeightToGoogleFit,
     r => `${r.weight} kg`
+  );
+}
+
+export async function syncAllCardio() {
+  return syncMany(
+    getUnsyncedCardio(),
+    syncCardioToGoogleFit,
+    s => `${s.type === 'bike' ? 'Vélo' : 'Marche'} ${s.duration || ''} min`
   );
 }
 

--- a/src/services/GoogleFitSync.js
+++ b/src/services/GoogleFitSync.js
@@ -53,7 +53,7 @@ export function isSyncedWithGoogleFit(category, id) {
 export async function syncWorkoutToGoogleFit(workout) {
   const endTime = new Date(workout.date).getTime();
   await GoogleFitService.addActivity({
-    activityType: 97, // Strength Training
+    activityType: 80, // Strength training → affiché « Musculation » dans Google Fit
     name: `Project Fat Loss - ${workout.title || 'Entraînement'}`,
     description: `Séance de musculation. Poids total soulevé : ${workout.weightLifted || 0} kg.`,
     startTime: endTime - DEFAULT_WORKOUT_DURATION_MS,


### PR DESCRIPTION
## Changements

### 1. Séances de l'historique = « Musculation »
`activityType` passe de `97` (Weightlifting / **Haltérophilie**) à **`80` = Strength training**, affiché **« Musculation »** dans Google Fit (FR).

### 2. Synchronisation du cardio (nouveau)
Les séances cardio (marche / vélo) n'étaient **pas prises en compte**. Ajout de la synchro Google Fit sur l'écran **Cardio**, en masse + par séance :
- `syncCardioToGoogleFit` : **marche → activityType 7 (Marche)**, **vélo → 1 (Vélo)** ; durée (min → ms), distance dans la description, calories.
- `getUnsyncedCardio` + `syncAllCardio`.
- `CardioTracker` : bouton de synchro en masse + bouton par séance (mêmes composants que les autres écrans).

## Tests
- `npm run build` ✅

https://claude.ai/code/session_01UaiQKFeCaSi5XWxdSTsbb3

## Summary by Sourcery

Update Google Fit synchronization to better categorize strength workouts and add support for syncing cardio sessions from the cardio tracker screen.

New Features:
- Add Google Fit synchronization for cardio sessions (walking and cycling) including duration, optional distance in the description, and calories.
- Expose mass-sync and per-session sync controls for cardio sessions in the cardio tracker UI.

Enhancements:
- Change the Google Fit activity type used for workout history sessions so they appear as strength training (“Musculation”) in Google Fit.
- Extend generic sync utilities to handle retrieving and bulk-syncing unsynced cardio sessions to Google Fit.