### PR TITLE
Suite revue PR #22 : reset basé sur un identifiant stable + sizing tablette via sx

### DIFF
--- a/src/pages/StepWorkout.css
+++ b/src/pages/StepWorkout.css
@@ -394,42 +394,20 @@
 }
 
 /* ============================================================
-   Mode tablette : élargir la fiche de détail d'exercice
+   Mode tablette/desktop : élargir le conteneur de la séance.
+   Le conteneur .day-content est plafonné à 800px (index.css) ; on relève
+   ce plafond pour que la fiche puisse s'élargir. La largeur de la fiche,
+   son padding et la taille de l'illustration sont gérés via les props `sx`
+   (breakpoints MUI md=900px / lg=1200px) côté composant, sans !important.
    ============================================================ */
-@media (min-width: 768px) {
-  /* Le conteneur .day-content est plafonné à 800px (index.css) : on
-     l'élargit pendant la séance pour que la fiche occupe mieux l'écran. */
+@media (min-width: 900px) {
   .day-content {
     max-width: 960px;
   }
-
-  .day-content .exercise-detail-wrapper {
-    width: 100%;
-    max-width: 760px;
-    margin-left: auto;
-    margin-right: auto;
-  }
-
-  .day-content .exercise-detail-card {
-    padding: 40px !important;
-  }
-
-  /* Illustration plus grande pour profiter de la largeur disponible */
-  .exercise-illustration {
-    max-width: 360px !important;
-  }
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 1200px) {
   .day-content {
     max-width: 1100px;
-  }
-
-  .day-content .exercise-detail-wrapper {
-    max-width: 860px;
-  }
-
-  .exercise-illustration {
-    max-width: 420px !important;
   }
 }

--- a/src/pages/StepWorkout.jsx
+++ b/src/pages/StepWorkout.jsx
@@ -977,8 +977,9 @@ export default function StepWorkout({ dayIndex: initialDayIndex, onBack, onCompl
         />
 
         {!pause ? (
-          <StepSet 
+          <StepSet
             exo={day.exercises[step]}
+            step={step}
             setNum={setNum}
             totalSets={totalSets}
             onDone={handleSetComplete}
@@ -1040,7 +1041,7 @@ export default function StepWorkout({ dayIndex: initialDayIndex, onBack, onCompl
   );
 }
 
-function StepSet({ exo, setNum, totalSets, onDone, onCaloriesBurned, onExerciseCompleted, isPaused, dayIndex, autoMode }) {
+function StepSet({ exo, step, setNum, totalSets, onDone, onCaloriesBurned, onExerciseCompleted, isPaused, dayIndex, autoMode }) {
   const [timer, setTimer] = useState(() => {
     if (exo.timer) {
       return exo.duration || 30;
@@ -1140,10 +1141,11 @@ function StepSet({ exo, setNum, totalSets, onDone, onCaloriesBurned, onExerciseC
     }
     
     // Fonctionnalité d'annonce vocale désactivée
-    // Dépendances primitives (nom de l'exercice) plutôt que l'objet `exo` pour
-    // éviter de réinitialiser le compteur si la référence change sans que
-    // l'exercice ait réellement changé.
-  }, [exo?.name, setNum, totalSets]);
+    // Identifiant stable de la série en cours (jour + index d'exercice + série)
+    // plutôt que l'objet `exo` ou son nom : on réinitialise dès que l'exercice
+    // ou la série change réellement — y compris pour deux exercices homonymes —
+    // sans dépendre d'une référence d'objet qui pourrait changer sans raison.
+  }, [dayIndex, step, setNum, totalSets]);
 
   // Timer dégressif pour exercices avec duration spécifique
   useEffect(() => {
@@ -1365,12 +1367,22 @@ function StepSet({ exo, setNum, totalSets, onDone, onCaloriesBurned, onExerciseC
   return (
     // pb généreux : réserve l'espace occupé par les contrôles flottants fixes
     // (bottom: 30px) pour que la ligne de répétitions ne passe pas dessous.
-    <Box className="exercise-detail-wrapper" sx={{ p: 2, pb: '140px' }}>
+    <Box
+      className="exercise-detail-wrapper"
+      sx={{
+        p: 2,
+        pb: '140px',
+        // Élargir la fiche sur tablette/desktop (cf. .day-content élargi en CSS)
+        width: '100%',
+        maxWidth: { xs: '100%', md: 760, lg: 860 },
+        mx: 'auto'
+      }}
+    >
       <Paper
         elevation={3}
         className="exercise-detail-card"
         sx={{
-          p: 3,
+          p: { xs: 3, md: 5 },
           mb: 2,
           position: 'relative',
           minHeight: 300,
@@ -1493,27 +1505,31 @@ function StepSet({ exo, setNum, totalSets, onDone, onCaloriesBurned, onExerciseC
             )}
           </Box>
         )}
-        <div className="exercise-illustration" style={{
-          width: '100%',
-          maxWidth: '280px',
-          aspectRatio: '1/1',
-          borderRadius: '16px',
-          overflow: 'hidden', 
-          border: '1px solid rgba(255, 255, 255, 0.08)', 
-          background: '#070707', 
-          marginBottom: '20px', 
-          display: 'flex', 
-          alignItems: 'center', 
-          justifyContent: 'center',
-          boxShadow: '0 8px 32px rgba(0, 0, 0, 0.45)',
-          position: 'relative'
-        }}>
-          <img 
-            src={getAssetPath(`/illustrations/${getExerciseIllustration(iconType, exo.name)}`)} 
-            alt={exo.name} 
-            style={{ width: '100%', height: '100%', objectFit: 'cover' }} 
+        <Box
+          className="exercise-illustration"
+          sx={{
+            width: '100%',
+            // Illustration agrandie sur tablette/desktop (remplace les overrides CSS !important)
+            maxWidth: { xs: 280, md: 360, lg: 420 },
+            aspectRatio: '1/1',
+            borderRadius: '16px',
+            overflow: 'hidden',
+            border: '1px solid rgba(255, 255, 255, 0.08)',
+            background: '#070707',
+            mb: '20px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            boxShadow: '0 8px 32px rgba(0, 0, 0, 0.45)',
+            position: 'relative'
+          }}
+        >
+          <img
+            src={getAssetPath(`/illustrations/${getExerciseIllustration(iconType, exo.name)}`)}
+            alt={exo.name}
+            style={{ width: '100%', height: '100%', objectFit: 'cover' }}
           />
-        </div>
+        </Box>
         
         <Typography 
           variant="h6" 


### PR DESCRIPTION
## Suite de la revue de la PR #22

Deux retours de revue traités.

### 1. Dépendance `exo?.name` de l'effet de reset
**Retour :** `exo?.name` peut sauter des resets nécessaires si d'autres propriétés d'un exercice homonyme changent (ou si deux exercices portent le même nom).

**Correctif :** `StepSet` reçoit désormais l'index d'exercice `step`, et l'effet de réinitialisation dépend d'un **identifiant stable de la série** : `[dayIndex, step, setNum, totalSets]`. Le compteur se réinitialise dès que l'exercice ou la série change réellement — y compris pour deux exercices homonymes — sans dépendre d'une référence d'objet potentiellement instable ni du seul nom.

### 2. `!important` pour surcharger les styles inline
**Retour :** les styles responsives s'appuyaient sur `!important` pour surcharger les props `sx`/`style` inline (`.exercise-illustration`, `.exercise-detail-card`).

**Correctif :** les valeurs de `max-width`/`padding` responsives passent maintenant par les props `sx` (breakpoints MUI `md`=900px / `lg`=1200px) :
- Wrapper : `maxWidth: { xs: '100%', md: 760, lg: 860 }`, centré via `mx: 'auto'`.
- Fiche (`Paper`) : `p: { xs: 3, md: 5 }`.
- Illustration : le `<div>` devient un `<Box>` avec `maxWidth: { xs: 280, md: 360, lg: 420 }`.

Le CSS ne conserve plus que l'élargissement du conteneur `.day-content` (relève le plafond de 800px), aligné sur les mêmes breakpoints 900px/1200px. Plus aucun `!important`.

## Vérifications
- `npx vite build` ✅

https://claude.ai/code/session_01Ku3ii9tXvCsKmELCNxF5WA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ku3ii9tXvCsKmELCNxF5WA)_

## Summary by Sourcery

Refine workout step reset logic to rely on a stable series identifier and adjust exercise detail layout sizing using responsive MUI sx props instead of CSS overrides.

Bug Fixes:
- Ensure the exercise set timer and related state reset reliably based on a stable identifier combining day, exercise index, set number, and total sets, avoiding missed resets for homonymous or updated exercises.

Enhancements:
- Pass the exercise index into StepSet and base the reset effect on day and exercise indices plus set metadata for more predictable behavior.
- Move tablet/desktop width, padding, and illustration sizing of the exercise detail view from CSS media queries and !important overrides into responsive MUI sx props on the layout components.
- Simplify StepWorkout CSS so that only the overall day-content container width is adjusted at larger breakpoints, relying on component-level styling for card and illustration sizing.