### PR TITLE
Corrige la page blanche en production : AudioContext instancié paresseusement

### DIFF
--- a/src/pages/StepWorkout.jsx
+++ b/src/pages/StepWorkout.jsx
@@ -136,27 +136,51 @@ const WorkoutContext = createContext({
   autoMode: false,
 });
 
-// Créer un contexte audio unique pour toute l'application
-const audioContext = new (window.AudioContext || window.webkitAudioContext)();
+// Contexte audio unique, créé paresseusement au premier usage.
+// IMPORTANT : ne PAS instancier au chargement du module. Sur certains
+// navigateurs (politique d'autoplay, AudioContext indisponible, modes
+// restreints…) `new AudioContext()` peut lever une exception ; comme ce code
+// s'exécute pendant l'évaluation du module (avant le montage de React), cela
+// fait planter tout le graphe d'import et aboutit à une page blanche que
+// l'ErrorBoundary ne peut pas intercepter.
+let audioContext = null;
+
+function getAudioContext() {
+  if (typeof window === 'undefined') return null;
+  const AudioCtor = window.AudioContext || window.webkitAudioContext;
+  if (!AudioCtor) return null;
+  if (!audioContext) {
+    try {
+      audioContext = new AudioCtor();
+    } catch (error) {
+      console.warn('AudioContext indisponible:', error);
+      return null;
+    }
+  }
+  return audioContext;
+}
 
 function playBeep() {
   try {
+    const ctx = getAudioContext();
+    if (!ctx) return;
+
     // Créer un oscillateur pour générer le son
-    const oscillator = audioContext.createOscillator();
-    const gainNode = audioContext.createGain();
-    
+    const oscillator = ctx.createOscillator();
+    const gainNode = ctx.createGain();
+
     // Connecter les nœuds
     oscillator.connect(gainNode);
-    gainNode.connect(audioContext.destination);
-    
+    gainNode.connect(ctx.destination);
+
     // Configurer le son
     oscillator.type = 'sine';
-    oscillator.frequency.setValueAtTime(800, audioContext.currentTime);
-    gainNode.gain.setValueAtTime(0.1, audioContext.currentTime);
-    
+    oscillator.frequency.setValueAtTime(800, ctx.currentTime);
+    gainNode.gain.setValueAtTime(0.1, ctx.currentTime);
+
     // Jouer le son
     oscillator.start();
-    oscillator.stop(audioContext.currentTime + 0.1);
+    oscillator.stop(ctx.currentTime + 0.1);
   } catch (error) {
     console.error("Erreur lors de la lecture du son:", error);
   }


### PR DESCRIPTION
## Problème
La page de production https://jhouedanou.github.io/projectfatloss/ reste **blanche**.

## Diagnostic
- Les déploiements **réussissent** (le dernier date du merge de la PR #22) et le `index.html` servi sur `gh-pages` est correct (bon `base` `/projectfatloss/assets/...`, `#root` présent).
- Le bundle ne contient **aucune** référence `process.env` résiduelle (Vite les remplace).
- En revanche, `StepWorkout.jsx` instanciait un **`AudioContext` au niveau module** :
  ```js
  const audioContext = new (window.AudioContext || window.webkitAudioContext)();
  ```
  Ce code s'exécute pendant l'**évaluation du module**, donc **avant le montage de React**. Sur certains navigateurs/contextes (politique d'autoplay, API absente, modes restreints), ce constructeur peut lever une exception → tout le graphe d'import échoue → page blanche. L'`ErrorBoundary` (montée dans `main.jsx`) **ne peut pas** intercepter une erreur survenant à l'import.

## Correctif
`AudioContext` est désormais créé **paresseusement** au premier `playBeep()`, dans une fonction `getAudioContext()` protégée par `try/catch` qui renvoie `null` si l'audio est indisponible. L'application se monte donc toujours, même quand l'audio ne peut pas être initialisé (les bips sont simplement ignorés).

## Vérifications
- `npx vite build` ✅
- Le bundle ne construit plus l'`AudioContext` au niveau top-level (l'appel est maintenant à l'intérieur de la fonction protégée).

## Remarque
Les utilisateurs ayant déjà installé la PWA peuvent conserver un ancien service worker en cache : un rechargement forcé (ou la fermeture/réouverture de l'app) peut être nécessaire pour récupérer le nouveau bundle après déploiement.

https://claude.ai/code/session_01Ku3ii9tXvCsKmELCNxF5WA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ku3ii9tXvCsKmELCNxF5WA)_

## Summary by Sourcery

Make AudioContext initialization lazy and resilient to errors to avoid production blank page caused by module-level instantiation failures.

Bug Fixes:
- Prevent the app from failing to mount with a blank page when AudioContext construction throws during module evaluation.

Enhancements:
- Create the audio context lazily on first beep playback via a guarded accessor that handles unavailable or failing audio APIs without breaking the app.