### PR TITLE
Review: tokeniser les couleurs sombres + contraste AA du texte tertiaire

### DIFF
--- a/src/components/DayPills.jsx
+++ b/src/components/DayPills.jsx
@@ -118,7 +118,7 @@ function DayPills({ days, current, setCurrent, setStepMode }) {
               ? 'rgba(255, 255, 255, 0.02)'
               : 'transparent',
           color: isActive ? '#fff' : (isCompleted ? '#aaa' : '#666'),
-          boxShadow: isActive ? '0 2px 8px rgba(240, 61, 50, 0.25)' : 'none',
+          boxShadow: isActive ? '0 2px 8px rgba(var(--accent-rgb), 0.25)' : 'none',
         }}
       >
         <IconComponent size={18} color={iconColor} strokeWidth={isActive ? 2.5 : 2} />

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,8 @@
 :root {
   /* Notre nouvelle palette de couleurs */
   --vermilion: #f03d32ff;
+  --accent-rgb: 240, 61, 50;        /* #f03d32 décomposé pour rgba() */
+  --illustration-surface: #101013;  /* fond sombre des illustrations d'exercice */
   --vermilion-2: #f13d30ff;
   --cinnabar: #f34430ff;
   --cinnabar-2: #f6452fff;
@@ -66,23 +68,23 @@
   --card-bg: rgba(24, 24, 27, 0.8);
   --card-shadow: rgba(240, 61, 50, 0.15);
   --text-secondary: #a1a1aa; 
-  --text-tertiary: #71717a; 
+  --text-tertiary: #82828b; /* éclairci pour contraste AA (>=4.5) sur fond et cartes */
   --button-bg: #f03d32ff;
   --button-text: #ffffff;
   --button-active: #c41e0b;
   --series-text: #ff9800; /* Orange vibrant */
   --color-neutral-200: rgba(255, 255, 255, 0.05);
   --color-neutral-300: rgba(255, 255, 255, 0.1);
-  background-color: #09090b; 
+  background-color: var(--bg-primary); 
 }
 
 /* S'assurer que tous les éléments du corps en mode sombre ont un fond cohérent */
 .dark-theme .app {
-  background-color: #09090b;
+  background-color: var(--bg-primary);
 }
 
 .dark-theme .day-content {
-  background-color: #09090b;
+  background-color: var(--bg-primary);
 }
 
 /* Transitions */
@@ -95,7 +97,7 @@
 
 html.dark-theme, 
 body.dark-theme {
-  background-color: #09090b;
+  background-color: var(--bg-primary);
   color: var(--seashell);
 }
 
@@ -1581,9 +1583,9 @@ gap:1rem;
 }
 
 @keyframes pulse-glow {
-  0% { box-shadow: 0 0 0 0 rgba(240, 61, 50, 0.28); }
-  70% { box-shadow: 0 0 0 8px rgba(240, 61, 50, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(240, 61, 50, 0); }
+  0% { box-shadow: 0 0 0 0 rgba(var(--accent-rgb), 0.28); }
+  70% { box-shadow: 0 0 0 8px rgba(var(--accent-rgb), 0); }
+  100% { box-shadow: 0 0 0 0 rgba(var(--accent-rgb), 0); }
 }
 
 .rest-btn {

--- a/src/pages/StepWorkout.jsx
+++ b/src/pages/StepWorkout.jsx
@@ -1595,7 +1595,7 @@ function StepSet({ exo, exercises = [], step, setNum, totalSets, onDone, onCalor
             borderRadius: '16px',
             overflow: 'hidden',
             border: '1px solid rgba(255, 255, 255, 0.08)',
-            background: '#101013',
+            background: 'var(--illustration-surface, #101013)',
             mb: '14px',
             display: 'flex',
             alignItems: 'center',


### PR DESCRIPTION
Suite aux commentaires de revue sur le polish design :
- Couleurs en dur remplacées par des tokens : fonds #09090b -> var(--bg-primary) ; ajout de --accent-rgb (rgba des lueurs) et --illustration-surface (#101013) ; keyframe pulse-glow, ombre des pastilles de jour et fond d'illustration utilisent désormais ces variables.
- --text-tertiary (mode sombre) #71717a -> #82828b : passe le ratio de contraste WCAG AA (>= 4.5) sur le fond (5.22) et sur les cartes (4.65), au lieu de 4.12 / 3.67 auparavant.

## Summary by Sourcery

Tokenize dark theme accent and background colors and adjust tertiary text color to meet AA contrast requirements.

Enhancements:
- Introduce CSS tokens for accent glow color and illustration surface backgrounds in dark mode.
- Replace hard-coded dark backgrounds with the shared bg-primary token across app containers and day content.
- Update pulse-glow animation and day pill shadows to use the accent color token for consistent theming.
- Lighten tertiary text color in dark mode to achieve WCAG AA contrast on main background and cards.